### PR TITLE
Application fails to build otherwise

### DIFF
--- a/src/components/VForm.tsx
+++ b/src/components/VForm.tsx
@@ -1,4 +1,4 @@
-import { CommonEvents } from '@/shared/types';
+import { CommonEvents } from '..//shared/types';
 import { ofType } from 'vue-tsx-support';
 import { VForm } from 'vuetify/lib';
 

--- a/src/components/VForm.tsx
+++ b/src/components/VForm.tsx
@@ -1,4 +1,4 @@
-import { CommonEvents } from '..//shared/types';
+import { CommonEvents } from '../shared/types';
 import { ofType } from 'vue-tsx-support';
 import { VForm } from 'vuetify/lib';
 


### PR DESCRIPTION
Hey,

so I noticed if we use @/shared/types instead ../ then the build fails and it results in an error. This should fix it.