### PR TITLE
fix Cannot find module '@/shared/types'.

### DIFF
--- a/src/components/VForm.tsx
+++ b/src/components/VForm.tsx
@@ -1,4 +1,4 @@
-import { CommonEvents } from '@/shared/types';
+import { CommonEvents } from '../shared/types';
 import { ofType } from 'vue-tsx-support';
 import { VForm } from 'vuetify/lib';
 


### PR DESCRIPTION
I tried to use this in vue-cli and got an error.

ERROR in C:/vuetify-tsx-test/node_modules/vuetify-tsx/lib/components/VForm.d.ts(1,30):
1:30 Cannot find module '@/shared/types'.
  \> 1 | import { CommonEvents } from '@/shared/types';
      |                              ^
    2 | declare const _default: import("vue").VueConstructor<{
    3 |     _tsxattrs: import("vue-tsx-support").TsxComponentAttrs<Props, CommonEvents, {}>;
    4 | } & import("vue").default>;
<s\> [webpack.Progress] 100%